### PR TITLE
Updates & bugfixes

### DIFF
--- a/.github/workflows/ci-branch.yml
+++ b/.github/workflows/ci-branch.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/ci-branch.yml
+++ b/.github/workflows/ci-branch.yml
@@ -23,7 +23,7 @@ jobs:
         run: dotnet build --no-restore
 
       - name: Test
-        run: dotnet test -- --coverage --coverage-output-format xml --coverage-output coverage.xml
+        run: dotnet test --collect:"XPlat Code Coverage"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -23,7 +23,7 @@ jobs:
         run: dotnet build --no-restore
 
       - name: Test
-        run: dotnet test -- --coverage --coverage-output-format xml --coverage-output coverage.xml
+        run: dotnet test --collect:"XPlat Code Coverage"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/DynamicDnsClient.Tests/DynamicDnsClient.Tests.csproj
+++ b/DynamicDnsClient.Tests/DynamicDnsClient.Tests.csproj
@@ -5,7 +5,7 @@
         <Nullable>enable</Nullable>
         <OutputType>Exe</OutputType>
         <RootNamespace>DynamicDnsClient.Tests</RootNamespace>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <!-- Enable the Microsoft Testing Platform 'dotnet test' experience -->
         <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
         <!-- Enable the Microsoft Testing Platform native command line experience -->
@@ -21,11 +21,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/>
-        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-        <PackageReference Include="WireMock.Net" Version="1.7.4" />
-        <PackageReference Include="xunit.v3" Version="2.0.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+        <PackageReference Include="WireMock.Net" Version="2.3.0" />
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/DynamicDnsClient.Tests/DynamicDnsClient.Tests.csproj
+++ b/DynamicDnsClient.Tests/DynamicDnsClient.Tests.csproj
@@ -22,7 +22,6 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-        <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
         <PackageReference Include="WireMock.Net" Version="2.3.0" />
         <PackageReference Include="xunit.v3" Version="3.2.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DynamicDnsClient.Tests/DynamicDnsTests.cs
+++ b/DynamicDnsClient.Tests/DynamicDnsTests.cs
@@ -35,7 +35,7 @@ public class DynamicDnsTests : IDisposable
         var httpClient = new HttpClient();
         var publicIpClient = new PublicIpHttpClient(httpClient, _configReader, _logger);
         var dynamicDnsClient = new DynamicDnsHttpClient(httpClient, _configReader, _logger);
-        var persistentStateHandler = new PersistentSateHandler(_configReader, _logger);
+        var persistentStateHandler = new PersistentStateHandler(_configReader, _logger);
         
         _dynamicDns = new DynamicDns(_configReader, publicIpClient, dynamicDnsClient, persistentStateHandler, _logger);
     }
@@ -50,10 +50,10 @@ public class DynamicDnsTests : IDisposable
         SetUpDdnsApis();
         
         // Act
-        await _dynamicDns!.UpdateIpAddressesAsync();
+        await _dynamicDns.UpdateIpAddressesAsync();
         
         // Assert
-        var requestedUrls = _mockServer.LogEntries.Select(l => l.RequestMessage.AbsoluteUrl).ToArray();
+        var requestedUrls = _mockServer.LogEntries.Select(l => l.RequestMessage?.AbsoluteUrl).ToArray();
         var savedIp = await File.ReadAllTextAsync(_runConfig.SavedStateFilePath, _ct);
         
         Assert.Equal(ip, savedIp);
@@ -73,14 +73,41 @@ public class DynamicDnsTests : IDisposable
         SetUpDdnsApis();
         
         // Act
-        await _dynamicDns!.UpdateIpAddressesAsync();
+        await _dynamicDns.UpdateIpAddressesAsync();
         
         // Assert
-        var requestedUrls = _mockServer.LogEntries.Select(l => l.RequestMessage.AbsoluteUrl).ToArray();
+        var requestedUrls = _mockServer.LogEntries.Select(l => l.RequestMessage?.AbsoluteUrl).ToArray();
         var savedIp = await File.ReadAllTextAsync(_runConfig.SavedStateFilePath, _ct);
         
         Assert.Equal(ip, savedIp);
         Assert.DoesNotContain(_logger.Logs!, msg => msg.Contains("[ERR]"));
+        GetExpectedUrlCalls(ip).ForEach(expectedUrl => Assert.Contains(expectedUrl, requestedUrls));
+    }
+
+    [Fact]
+    public async Task UpdatesAllInstancesWithNewIpWhenFirstProvidersReturnInvalidResponses()
+    {
+        // Arrange
+        const string ip = "90.62.59.132";
+
+        var ipApiUrls = _runConfig.IpProviderUrls!;
+
+        SetUpPublicIpApi(ipApiUrls[0], "<html><body>Error 503</body></html>");
+        SetUpPublicIpApi(ipApiUrls[1], "not-an-ip");
+        SetUpPublicIpApi(ipApiUrls[2], ip);
+        SetUpDdnsApis();
+
+        // Act
+        await _dynamicDns.UpdateIpAddressesAsync();
+
+        // Assert
+        var requestedUrls = _mockServer.LogEntries.Select(l => l.RequestMessage?.AbsoluteUrl).ToArray();
+        var savedIp = await File.ReadAllTextAsync(_runConfig.SavedStateFilePath, _ct);
+
+        Assert.Equal(ip, savedIp);
+        Assert.DoesNotContain(_logger.Logs!, msg => msg.Contains("[ERR]"));
+        Assert.Contains(_logger.Logs!, msg => msg.Contains("[WRN]") && msg.Contains(ipApiUrls[0]));
+        Assert.Contains(_logger.Logs!, msg => msg.Contains("[WRN]") && msg.Contains(ipApiUrls[1]));
         GetExpectedUrlCalls(ip).ForEach(expectedUrl => Assert.Contains(expectedUrl, requestedUrls));
     }
 
@@ -96,10 +123,10 @@ public class DynamicDnsTests : IDisposable
         await File.WriteAllTextAsync(_runConfig.SavedStateFilePath, ip, _ct);
         
         // Act
-        await _dynamicDns!.UpdateIpAddressesAsync();
+        await _dynamicDns.UpdateIpAddressesAsync();
         
         // Assert
-        var requestedUrls = _mockServer.LogEntries.Select(l => l.RequestMessage.AbsoluteUrl).ToArray();
+        var requestedUrls = _mockServer.LogEntries.Select(l => l.RequestMessage?.AbsoluteUrl).ToArray();
         var savedIp = await File.ReadAllTextAsync(_runConfig.SavedStateFilePath, _ct);
         
         Assert.Equal(ip, savedIp);
@@ -119,10 +146,10 @@ public class DynamicDnsTests : IDisposable
         File.Delete(_configReader.AppConfigPath);
         
         // Act
-        await _dynamicDns!.UpdateIpAddressesAsync();
+        await _dynamicDns.UpdateIpAddressesAsync();
         
         // Assert
-        var requestedUrls = _mockServer.LogEntries.Select(l => l.RequestMessage.AbsoluteUrl).ToArray();
+        var requestedUrls = _mockServer.LogEntries.Select(l => l.RequestMessage?.AbsoluteUrl).ToArray();
         var hasSavedIp = File.Exists(_runConfig.SavedStateFilePath);
         
         Assert.False(hasSavedIp);
@@ -155,10 +182,10 @@ public class DynamicDnsTests : IDisposable
         }
         
         // Act
-        await _dynamicDns!.UpdateIpAddressesAsync();
+        await _dynamicDns.UpdateIpAddressesAsync();
         
         // Assert
-        var requestedUrls = _mockServer.LogEntries.Select(l => l.RequestMessage.AbsoluteUrl).ToArray();
+        var requestedUrls = _mockServer.LogEntries.Select(l => l.RequestMessage?.AbsoluteUrl).ToArray();
         var hasSavedIp = File.Exists(_runConfig.SavedStateFilePath);
         
         Assert.False(hasSavedIp);

--- a/DynamicDnsClient/Clients/PublicIpHttpClient.cs
+++ b/DynamicDnsClient/Clients/PublicIpHttpClient.cs
@@ -1,4 +1,6 @@
-﻿using DynamicDnsClient.Configuration;
+﻿using System.Net;
+using System.Net.Sockets;
+using DynamicDnsClient.Configuration;
 using DynamicDnsClient.Logging;
 
 namespace DynamicDnsClient.Clients;
@@ -18,11 +20,11 @@ public class PublicIpHttpClient : IPublicIpHttpClient
     
     public async Task<string?> GetPublicIpAsync()
     {
-        try
+        var appConfig = await _configReader.ReadConfigurationAsync();
+
+        foreach (var ipProviderUrl in appConfig!.IpProviderUrls!)
         {
-            var appConfig = await _configReader.ReadConfigurationAsync();
-            
-            foreach (var ipProviderUrl in appConfig!.IpProviderUrls!)
+            try
             {
                 using var request = new HttpRequestMessage();
 
@@ -35,23 +37,38 @@ public class PublicIpHttpClient : IPublicIpHttpClient
                     _logger.LogWarning(
                         $"Could not obtain public IP address from '{ipProviderUrl}'. " +
                         $"Status code: {response.StatusCode}");
-                    
+
                     continue;
                 }
-                    
+
                 var publicIp = (await response.Content.ReadAsStringAsync()).TrimEnd();
+
+                if (!IPAddress.TryParse(publicIp, out var address) ||
+                    address.AddressFamily != AddressFamily.InterNetwork)
+                {
+                    var truncatedResponse = publicIp.Length > 50
+                        ? publicIp[..50] + "..."
+                        : publicIp;
+
+                    _logger.LogWarning(
+                        $"Could not obtain public IP address from '{ipProviderUrl}'. " +
+                        $"Response is not a valid IPv4 address: '{truncatedResponse}'");
+
+                    continue;
+                }
 
                 _logger.LogTrace($"Public IP obtained from '{ipProviderUrl}': {publicIp}");
                 return publicIp;
             }
-            
-            _logger.LogWarning("Could not obtain public IP address from any configured providers.");
-            return null;
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    $"Could not obtain public IP address from '{ipProviderUrl}'. " +
+                    $"{ex.GetType().Name}: {ex.Message}");
+            }
         }
-        catch (Exception ex)
-        {
-            _logger.LogWarning($"Could not obtain public IP address. {ex.GetType().Name}: {ex.Message}");
-            return null;
-        }
+
+        _logger.LogWarning("Could not obtain public IP address from any configured providers.");
+        return null;
     }
 }

--- a/DynamicDnsClient/DynamicDns.cs
+++ b/DynamicDnsClient/DynamicDns.cs
@@ -10,20 +10,20 @@ public class DynamicDns
     private readonly IConfigReader _configReader;
     private readonly IPublicIpHttpClient _publicIpHttpClient;
     private readonly IDynamicDnsHttpClient _dynamicDnsHttpClient;
-    private readonly IPersistentSateHandler _persistentSateHandler;
+    private readonly IPersistentStateHandler _persistentStateHandler;
     private readonly ILogger _logger;
 
     public DynamicDns(
         IConfigReader configReader,
         IPublicIpHttpClient publicIpHttpClient,
         IDynamicDnsHttpClient dynamicDnsHttpClient,
-        IPersistentSateHandler persistentSateHandler,
+        IPersistentStateHandler persistentStateHandler,
         ILogger logger)
     {
         _configReader = configReader;
         _publicIpHttpClient = publicIpHttpClient;
         _dynamicDnsHttpClient = dynamicDnsHttpClient;
-        _persistentSateHandler = persistentSateHandler;
+        _persistentStateHandler = persistentStateHandler;
         _logger = logger;
     }
     
@@ -32,37 +32,37 @@ public class DynamicDns
         var config = await _configReader.ReadConfigurationAsync();
         if (config is null)
         {
-            _logger.LogError($"Dynamic DNS client is exiting due to invalid configuration.");
+            _logger.LogError("Dynamic DNS client is exiting due to invalid configuration.");
             return;
         }
         
         _logger.LogTrace("Dynamic DNS client started.");
 
-        var lastUpdatedPublicIp = await _persistentSateHandler.GetLastUpdatedPublicIpAsync();
+        var lastUpdatedPublicIp = await _persistentStateHandler.GetLastUpdatedPublicIpAsync();
 
         var newPublicIp = await _publicIpHttpClient.GetPublicIpAsync();
         if (newPublicIp is null)
         {
             _logger.LogTrace(
-                $"Dynamic DNS client is exiting due to being unable to obtain public IP.");
+                "Dynamic DNS client is exiting due to being unable to obtain public IP.");
     
             return;
         }
 
         if (string.Equals(newPublicIp, lastUpdatedPublicIp))
         {
-            _logger.LogTrace($"Dynamic DNS client is exiting: IP update is not needed.");
+            _logger.LogTrace("Dynamic DNS client is exiting: IP update is not needed.");
             return;
         }
 
         if (await _dynamicDnsHttpClient.UpdateIpForDnsAsync(newPublicIp))
         {
-            await _persistentSateHandler.UpdateLastUpdatedPublicIpAsync(newPublicIp);
-            _logger.LogTrace($"Dynamic DNS client is exiting: run completed.");
+            await _persistentStateHandler.UpdateLastUpdatedPublicIpAsync(newPublicIp);
+            _logger.LogTrace("Dynamic DNS client is exiting: run completed.");
         }
         else
         {
-            _logger.LogError($"Dynamic DNS client was unable to update public IP.");
+            _logger.LogError("Dynamic DNS client was unable to update public IP.");
         }
     }
 }

--- a/DynamicDnsClient/DynamicDnsClient.csproj
+++ b/DynamicDnsClient/DynamicDnsClient.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PublishAot>true</PublishAot>

--- a/DynamicDnsClient/Program.cs
+++ b/DynamicDnsClient/Program.cs
@@ -13,7 +13,7 @@ try
     var httpClient = new HttpClient();
     var publicIpClient = new PublicIpHttpClient(httpClient, configReader, logger);
     var dynamicDnsClient = new DynamicDnsHttpClient(httpClient, configReader, logger);
-    var persistentStateHandler = new PersistentSateHandler(configReader, logger);
+    var persistentStateHandler = new PersistentStateHandler(configReader, logger);
 
     var dynamicDns = new DynamicDns(configReader, publicIpClient, dynamicDnsClient, persistentStateHandler, logger);
     await dynamicDns.UpdateIpAddressesAsync();

--- a/DynamicDnsClient/Saving/IPersistentStateHandler.cs
+++ b/DynamicDnsClient/Saving/IPersistentStateHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace DynamicDnsClient.Saving;
 
-public interface IPersistentSateHandler
+public interface IPersistentStateHandler
 {
     Task<string> GetLastUpdatedPublicIpAsync();
     Task UpdateLastUpdatedPublicIpAsync(string newIp);

--- a/DynamicDnsClient/Saving/PersistentStateHandler.cs
+++ b/DynamicDnsClient/Saving/PersistentStateHandler.cs
@@ -3,14 +3,14 @@ using DynamicDnsClient.Logging;
 
 namespace DynamicDnsClient.Saving;
 
-public class PersistentSateHandler : IPersistentSateHandler
+public class PersistentStateHandler : IPersistentStateHandler
 {
     private const string DefaultIp = "127.0.0.1";
     
     private readonly IConfigReader _configReader;
     private readonly ILogger _logger;
 
-    public PersistentSateHandler(IConfigReader configReader, ILogger logger)
+    public PersistentStateHandler(IConfigReader configReader, ILogger logger)
     {
         _configReader = configReader;
         _logger = logger;


### PR DESCRIPTION
**Summary**

  - Fix IP provider fallback bug: The try/catch in `PublicIpHttpClient` wrapped the entire provider loop, so any exception (DNS failure, timeout, connection refused) would skip all remaining providers. Moved it inside the loop so each provider fails independently.
  - Add IPv4 validation: Responses from IP providers are now validated as IPv4 addresses. HTML error pages, garbage, or IPv6 responses are rejected with a warning (truncated to 50 chars in the log) and the next provider is tried.
  - Fix "Sate" → "State" typo: Renamed `PersistentSateHandler` / `IPersistentSateHandler` in class names, interface, file names, and all references.
  - Upgrade to .NET 10: Updated target framework in both projects and CI workflows from net9.0 / 9.0.x to net10.0 / 10.0.x. Updated test dependencies to latest versions.

**Testing**

  - Added `UpdatesAllInstancesWithNewIpWhenFirstProvidersReturnInvalidResponses` — verifies fallback works when providers return HTML and non-IP strings
  - All 20 tests pass on .NET 10
  - Build produces 0 warnings, 0 errors